### PR TITLE
Fix Vercel build error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "functions": {
     "api/*.js": {
       "runtime": "nodejs18.x"


### PR DESCRIPTION
## Summary
- add missing `version` to `vercel.json`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688410c32be4832dbfc323b49e3f230c